### PR TITLE
feat: added driver standings page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       { index: true, element: <Home /> },
-      { path: "/drivers", element: <Drivers /> },
+      { path: "drivers", element: <Drivers /> },
       // { path: "drivers/:driverId", element: <DriverDetails /> },
       // { path: "calendar", element: <RaceCalendar /> },
       // { path: "races/:raceId", element: <RaceDetails /> },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css';
 import { createBrowserRouter, RouterProvider } from "react-router";
 import Home from './pages/Home/Home';
 import RootLayout from './layout/RootLayout';
+import Drivers from './pages/Home/Drivers/Drivers';
 
 const router = createBrowserRouter([
   {
@@ -9,7 +10,7 @@ const router = createBrowserRouter([
     element: <RootLayout />,
     children: [
       { index: true, element: <Home /> },
-      // { path: "drivers", element: <Drivers /> },
+      { path: "/drivers", element: <Drivers /> },
       // { path: "drivers/:driverId", element: <DriverDetails /> },
       // { path: "calendar", element: <RaceCalendar /> },
       // { path: "races/:raceId", element: <RaceDetails /> },

--- a/src/components/Footer/footer.css
+++ b/src/components/Footer/footer.css
@@ -9,5 +9,6 @@
 
     .footer-text {
         color: white;
+        text-align: center;
     }
 }

--- a/src/pages/Home/Drivers/Drivers.tsx
+++ b/src/pages/Home/Drivers/Drivers.tsx
@@ -1,0 +1,106 @@
+import { notification, Spin, Typography } from "antd";
+import { useEffect, useState } from "react";
+import { fetchDriverStandings } from "../../../api/f1";
+import dayjs from "dayjs";
+import { motion } from "framer-motion";
+import './drivers.css';
+
+interface Constructor {
+    colorCode: string;
+    name: string;
+}
+
+interface Driver {
+    givenName: string;
+    familyName: string;
+    nationality: string;
+    driverId: string;
+}
+
+interface DriverStanding {
+    position: string;
+    points: string;
+    wins: string;
+    Driver: Driver;
+    Constructors: Constructor[];
+}
+
+const Drivers = () => {
+    const [driverStandings, setDriverStandings] = useState<DriverStanding[]>([]);
+    const [loading, setLoading] = useState<boolean>(true);
+
+    const { Title, Paragraph, Text } = Typography;
+
+    const loadTopDrivers = async () => {
+        setLoading(true);
+        try {
+            const data = await fetchDriverStandings();
+            const standings = data || [];
+            setDriverStandings(standings);
+        } catch {
+            notification.error({
+                message: 'Error',
+                description: 'Failed to load top drivers. Please try again later.',
+                placement: 'bottomRight',
+            });
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        loadTopDrivers();
+    }, []);
+
+    return (
+        <div className="drivers-list-container">
+            <Title className="standings-title" level={2} >Formula 1 {dayjs().get('year')} Standings 🏆</Title>
+            <div className="drivers-list-grid">
+                {!loading && driverStandings.length > 0 && (
+                    driverStandings.map((driver) => {
+                        const { position, points, wins, Driver: { givenName, familyName, nationality, driverId } } = driver;
+                        const constructorName = driver.Constructors[0].name;
+                        const colorCode = driver.Constructors[0].colorCode;
+
+                        return (
+                            <motion.div
+                                key={driverId}
+                                className="driver-card"
+                                style={{ borderTop: `5px solid ${colorCode}` }}
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                whileHover={{ scale: 1.03 }}
+                                transition={{ duration: 0.4 }}
+                            >
+                                <Title level={4}>
+                                    {position === "1" ? "👑" : `#${position}`} {`${givenName} ${familyName}`}
+                                </Title>
+
+                                <Paragraph strong>{constructorName}</Paragraph>
+
+                                <div className="driver-stats">
+                                    <Paragraph strong>🏁 {points} pts</Paragraph>
+                                    <Paragraph strong>🏆 {wins} wins</Paragraph>
+                                </div>
+
+                                <Text strong>🌍 {nationality}</Text>
+                            </motion.div>
+                        );
+                    })
+                )}
+
+
+            </div>
+
+            {loading && driverStandings.length === 0 && <Spin size="large" />}
+
+            {!loading && driverStandings.length === 0 && (
+                <Text type="secondary">
+                    No driver standings available at the moment. Please check back later.
+                </Text>)
+            }
+        </div>
+    );
+};
+
+export default Drivers;

--- a/src/pages/Home/Drivers/drivers.css
+++ b/src/pages/Home/Drivers/drivers.css
@@ -1,0 +1,35 @@
+.drivers-list-container {
+    padding: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    .standings-title {
+        text-align: center;
+    }
+
+    .drivers-list-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
+        gap: 16px;
+
+        .driver-card {
+            background-color: #fff;
+            border-radius: 12px;
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.07);
+            padding: 16px;
+            text-align: center;
+            transition: all 0.3s ease;
+            display: flex;
+            flex-direction: column;
+            justify-content: space-between;
+            gap: 8px;
+        }
+
+        .driver-stats {
+            display: flex;
+            justify-content: space-around;
+        }
+
+    }
+}

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -94,7 +94,7 @@ const Home = () => {
             >
                 <Title level={1}>F1 Central</Title>
             </motion.div>
-            <Title level={2}>Driver Championship Standings 🏆</Title>
+            <Title level={2}>Drivers Championship Standings 🏆</Title>
             <Title level={4}>
                 {dayjs().get('year')} Formula 1 Season
             </Title>

--- a/src/pages/Home/home.css
+++ b/src/pages/Home/home.css
@@ -8,7 +8,6 @@
     .top-drivers-grid {
         display: grid;
         gap: 16px;
-        /* grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); */
 
         .driver-card {
             display: flex;
@@ -22,7 +21,6 @@
     }
 
     .upcoming-races-container {
-
         .upcoming-races-grid {
             display: grid;
             gap: 16px;


### PR DESCRIPTION
This pull request introduces a new `Drivers` page to display Formula 1 driver standings, along with various supporting changes across multiple files. Key updates include the addition of the `Drivers` component, routing adjustments, styling for the new page, and minor text corrections elsewhere in the application.

### New `Drivers` Page:

* Added a new `Drivers` component to display Formula 1 driver standings, including loading states, error handling, and animations for driver cards.
* Created new styles for the `Drivers` page, including layout and card designs for the driver standings.

### Routing Updates:

* [`src/App.tsx`](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R5-R13): Enabled routing for the new `Drivers` page by importing the component and adding a path `/drivers`.

### Styling Adjustments:

* [`src/components/Footer/footer.css`](diffhunk://#diff-625a829a4d585fb3a1d915f0aad31851bf02940cee0f43ae201c376b51f69029R12): Center-aligned footer text for improved visual consistency.
